### PR TITLE
Update to the latest possible docker (in docker) image

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -313,7 +313,7 @@ Resources:
         Type: CODEPIPELINE
       Environment:
         ComputeType: "BUILD_GENERAL1_LARGE"
-        Image: "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+        Image: "aws/codebuild/docker:19.03.8"
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -313,7 +313,7 @@ Resources:
         Type: CODEPIPELINE
       Environment:
         ComputeType: "BUILD_GENERAL1_LARGE"
-        Image: "aws/codebuild/docker:19.03.8"
+        Image: "aws/codebuild/docker:18.09.0"
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID


### PR DESCRIPTION
At this moment it is only supported version of docker by AWS.
Going forward, only [docker:dind](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html#sample-docker-custom-image-files) which requires `git` to be installed and maybe other packages.